### PR TITLE
Update state only if passedRecipes are set

### DIFF
--- a/src/components/SearchForm/Test/Test.js
+++ b/src/components/SearchForm/Test/Test.js
@@ -15,7 +15,7 @@ class Test extends Component {
 
   componentWillReceiveProps(newProps) {
     // console.log(JSON.stringify(this.state.recipes), JSON.stringify(newProps.passedRecipes[0]))
-    if(JSON.stringify(this.state.recipes) !== JSON.stringify(newProps.passedRecipes))
+    if(newProps.passedRecipes && JSON.stringify(this.state.recipes) !== JSON.stringify(newProps.passedRecipes))
         this.setState({recipes: newProps.passedRecipes})
     
   }


### PR DESCRIPTION
### Description
The componentWillReceiveProps in Test.js was setting state if the old and new props were not equal. This would also happen if the new props is undefined, causing the map inside the render to fail. I've added an additional check inside the function to setState only if the newProps has data.

#### Related issues

<!--
Please use the following link syntaxes:

- #49 (to reference issues in the current repository)
- ChickenKyiv/recipe-api-only#49 (to reference issues in another repository)
-->

- None

### Checklist

<!--
Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
-->

- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
